### PR TITLE
Make aioh2 work with Python >3.4

### DIFF
--- a/aioh2/helper.py
+++ b/aioh2/helper.py
@@ -4,7 +4,7 @@ import asyncio
 
 from .protocol import H2Protocol
 
-__all__ = ['open_connection', 'start_server']
+__all__ = ['open_connection', 'start_server', 'async_task']
 if hasattr(socket, 'AF_UNIX'):
     __all__.extend(['open_unix_connection', 'start_unix_server'])
 
@@ -84,6 +84,6 @@ if hasattr(socket, 'AF_UNIX'):
 
 
 if hasattr(asyncio, 'ensure_future'):  # Python >= 3.5
-    async_task = asyncio.ensure_future
+    async_task = getattr(asyncio, 'ensure_future')
 else:
-    async_task = asyncio.async
+    async_task = getattr(asyncio, 'async')

--- a/aioh2/protocol.py
+++ b/aioh2/protocol.py
@@ -10,7 +10,7 @@ from h2.config import H2Configuration
 from h2.connection import H2Connection
 from h2.exceptions import NoSuchStreamError, StreamClosedError, ProtocolError
 
-from . import exceptions
+from . import exceptions, async_task
 
 __all__ = ['H2Protocol']
 logger = getLogger(__package__)
@@ -380,7 +380,7 @@ class H2Protocol(asyncio.Protocol):
         if self._handler:
             raise Exception('Handler was already set')
         if handler:
-            self._handler = asyncio.async(handler, loop=self._loop)
+            self._handler = async_task(handler, loop=self._loop)
 
     def close_connection(self):
         self._transport.close()


### PR DESCRIPTION
The previous check for ensure_future() fails for Python 3.7. This fix
should work for Python 3.4-3.7 and newer.