### PR TITLE
Fix error import

### DIFF
--- a/aioh2/protocol.py
+++ b/aioh2/protocol.py
@@ -10,7 +10,7 @@ from h2.config import H2Configuration
 from h2.connection import H2Connection
 from h2.exceptions import NoSuchStreamError, StreamClosedError, ProtocolError
 
-from . import exceptions, async_task
+from . import exceptions
 
 __all__ = ['H2Protocol']
 logger = getLogger(__package__)


### PR DESCRIPTION
`from . import async_task` in #19  is needless and will cause error
`ImportError: cannot import name 'async_task' from 'aioh2'`